### PR TITLE
Log progress

### DIFF
--- a/cmd/segment/__main__.py
+++ b/cmd/segment/__main__.py
@@ -20,6 +20,7 @@ from modeling import factory as model_factory
 from pycocotools import mask as mask_api
 from typing_extensions import TypedDict
 from utils import box_utils, input_utils, mask_utils
+from counter import Counter
 
 DUMMY_FILENAME = "DUMMY_FILENAME"
 
@@ -346,6 +347,7 @@ def main(
         yield_single_examples=True,
     )
 
+    counter = Counter(total=len(image_files))
     prediction: Prediction
     for source_id, prediction in enumerate(predictor):
         filename = os.path.basename(image_files[source_id])
@@ -361,10 +363,16 @@ def main(
                 score_threshold=min_score_threshold,
             )
 
-        if dst == Destination.BQ:
-            insert_bq(bq_client, table, coco_annotations)
-        elif dst == Destination.LOCAL:
-            out_file.write("\n".join([json.dumps(a) for a in coco_annotations]) + "\n")
+            if dst == Destination.BQ:
+                insert_bq(bq_client, table, coco_annotations)
+            elif dst == Destination.LOCAL:
+                out_file.write(
+                    "\n".join([json.dumps(a) for a in coco_annotations]) + "\n"
+                )
+
+            counter.count_success(1)
+            counter.count_processed(1)
+            counter.log_progress()
 
     if dst == Destination.LOCAL:
         out_file.close()

--- a/cmd/segment/__main__.py
+++ b/cmd/segment/__main__.py
@@ -250,9 +250,7 @@ def insert_bq(
 ) -> None:
 
     errors = bq_client.insert_rows(result_table, rows_to_insert)  # Make an API request.
-    if errors == []:
-        print("New rows have been added.")
-    else:
+    if errors != []:
         print("Encountered errors while inserting rows: {}".format(errors))
 
 

--- a/cmd/segment/counter.py
+++ b/cmd/segment/counter.py
@@ -1,0 +1,86 @@
+import time
+from threading import Condition
+
+
+class TooManyErrorsOccured(Exception):
+    pass
+
+
+class Counter:
+    def __init__(
+        self,
+        total: int,
+        progress_interval: int = 1,
+        threshold_errors: "int | None" = None,
+    ) -> None:
+        self._processed = 0
+        self._success = 0
+        self._log_interval = progress_interval
+        self._total = total
+        self._start_at = time.perf_counter()
+        self._cond_processed = Condition()
+        self._cond_success = Condition()
+        self._threshold_errors = threshold_errors or int(total / 2)
+
+    @property
+    def processed(self) -> int:
+        return self._processed
+
+    @property
+    def success(self) -> int:
+        return self._success
+
+    @property
+    def start_at(self) -> float:
+        return self._start_at
+
+    @property
+    def total(self) -> int:
+        return self._total
+
+    @property
+    def percent(self) -> float:
+        return self.rate * 100
+
+    @property
+    def rate(self) -> float:
+        return self.processed / self._total
+
+    @property
+    def throughput(self) -> float:
+        return self.processed / self.elapsed_sec
+
+    @property
+    def elapsed_sec(self) -> float:
+        return time.perf_counter() - self.start_at
+
+    @property
+    def eta(self) -> str:
+        eta = (self._total - self.processed) / self.throughput
+        ss = int((eta % 60))
+        mm = int((eta / 60) % 60)
+        hh = int(eta // (60 * 60))
+        return f"ETA={hh:02}:{mm:02}:{ss:02}"
+
+    @property
+    def progress(self) -> str:
+        return f"{self.percent:.1f}[%]={self.processed}/{self._total}"
+
+    def __repr__(self) -> str:
+        return f"{self.progress}, " f"{1/self.throughput:.3f}[sec/iter], " f"{self.eta}"
+
+    def log_progress(self, log_fn=print) -> None:
+        if self.processed % self._log_interval == 0 or self.processed == self.total:
+            log_fn(self)
+
+    def count_processed(self, d: int) -> None:
+        with self._cond_processed:
+            self._processed += d
+
+    def count_success(self, d: int) -> None:
+        with self._cond_success:
+            self._success += d
+
+    def raise_for_many_errors(self) -> None:
+        if self.processed - self.success > self._threshold_errors:
+            raise TooManyErrorsOccured


### PR DESCRIPTION
# Change Summary

進捗、1枚あたりの所要時間、残り時間のログを追加。

# Why to Change

- データ量から所要時間を見積もれるようになり、作業の見通しを立てやすくするため
- パフォーマンスチューニング時に改善されたかどうか、定量的に判断できるようにするため
- 分散処理する場合に必要なマシンの台数を見積もれるようにするため

# How to Check and Result

コンフルのよくやる手順の通りに実行。

標準出力に以下が出力され、意図通りに動いていることがわかる。

```
33.3[%]=1/3, 54.254[sec/iter], ETA=00:01:48
66.7[%]=2/3, 27.134[sec/iter], ETA=00:00:27
100.0[%]=3/3, 19.796[sec/iter], ETA=00:00:00
```

# Document Update

不要