### PR TITLE
Add bbox and mask_area_fraction

### DIFF
--- a/cmd/segment/__main__.py
+++ b/cmd/segment/__main__.py
@@ -20,6 +20,7 @@ from modeling import factory as model_factory
 from pycocotools import mask as mask_api
 from typing_extensions import TypedDict
 from utils import box_utils, input_utils, mask_utils
+
 from counter import Counter
 
 DUMMY_FILENAME = "DUMMY_FILENAME"
@@ -169,7 +170,7 @@ class COCOAnnotation(TypedDict):
     image_id: int
     filename: str
     category_id: int
-    # bbox: list[float]
+    bbox: list[float]
     score: float
     segmentation: COCORLE
     mask_mean_score: float
@@ -231,9 +232,9 @@ def convert_predictions_to_coco_annotations(
             "image_id": int(image_id),
             "filename": prediction["filename"],
             "category_id": int(prediction["pred_detection_classes"][k]),
-            # "bbox": (
-            #    prediction["pred_detection_boxes"][k].astype(np.float32) / eval_scale
-            # ).tolist(),
+            "bbox": (
+                prediction["pred_detection_boxes"][k].astype(np.float32) / eval_scale
+            ).tolist(),
             "score": float(prediction["pred_detection_scores"][k]),
             "segmentation": encoded_masks[m],
             "mask_mean_score": mask_mean_scores[m],

--- a/cmd/segment/__main__.py
+++ b/cmd/segment/__main__.py
@@ -166,11 +166,25 @@ class Prediction(TypedDict):
     pred_detection_masks: np.array  # (num_detections, mask_height, mask_width)
 
 
+# TODO: 接頭辞の Bbox を取るために、
+# COCOAnnotation や convert_pred... を別ファイルに移す。
+# Bbox を付けてる理由は、 COCORLE の Width, Height と衝突するから。
+BboxLeft = NewType("BboxLeft", float)
+BboxTop = NewType("BboxTop", float)
+BboxWidth = NewType("BboxWidth", float)
+BboxHeight = NewType("BboxHeight", float)
+
+
 class COCOAnnotation(TypedDict):
     image_id: int
     filename: str
     category_id: int
-    bbox: list[float]
+    # Avoid `bbox: list[float]` because
+    # it's hard to know what each dimension means.
+    # Also avoid `dict` like `{"left", "top", "width", "heiht"}`
+    # along with the official COCO schema,
+    # which adopts `list` instead of `dict`.
+    bbox: tuple[BboxLeft, BboxTop, BboxWidth, BboxHeight]
     mask_area_fraction: float
     score: float
     segmentation: COCORLE
@@ -189,6 +203,23 @@ def convert_predictions_to_coco_annotations(
     output_image_size: int = None,
     score_threshold=0.05,
 ) -> list[COCOAnnotation]:
+    """This is made, modifying a function of the same name in
+    /tf_tpu_models/official/detection/evaluation/coco_utils.py
+
+    Parameters
+    ----------
+    prediction : Prediction
+        [description]
+    output_image_size : int, optional
+        [description], by default None
+    score_threshold : float, optional
+        [description], by default 0.05
+
+    Returns
+    -------
+    list[COCOAnnotation]
+        [description]
+    """
     prediction["pred_detection_boxes"] = box_utils.yxyx_to_xywh(
         prediction["pred_detection_boxes"]
     )
@@ -234,9 +265,11 @@ def convert_predictions_to_coco_annotations(
             "image_id": int(image_id),
             "filename": prediction["filename"],
             "category_id": int(prediction["pred_detection_classes"][k]),
-            "bbox": (
-                prediction["pred_detection_boxes"][k].astype(np.float32) / eval_scale
-            ).tolist(),
+            # Avoid `astype(np.float32)` because
+            # it can't be serialized as JSON.
+            "bbox": tuple(
+                float(x) for x in prediction["pred_detection_boxes"][k] / eval_scale
+            ),
             "mask_area_fraction": float(mask_area_fractions[m]),
             "score": float(prediction["pred_detection_scores"][k]),
             "segmentation": encoded_masks[m],

--- a/cmd/segment/__main__.py
+++ b/cmd/segment/__main__.py
@@ -222,6 +222,7 @@ def convert_predictions_to_coco_annotations(
 
     mask_masks = (predicted_masks > 0.5).astype(np.float32)
     mask_areas = mask_masks.sum(axis=-1).sum(axis=-1)
+    mask_area_fractions = (mask_areas / np.prod(predicted_masks.shape[1:])).tolist()
     mask_mean_scores = (
         (predicted_masks * mask_masks).sum(axis=-1).sum(axis=-1) / mask_areas
     ).tolist()
@@ -236,7 +237,7 @@ def convert_predictions_to_coco_annotations(
             "bbox": (
                 prediction["pred_detection_boxes"][k].astype(np.float32) / eval_scale
             ).tolist(),
-            "mask_area_fraction": float(mask_areas[m]),
+            "mask_area_fraction": float(mask_area_fractions[m]),
             "score": float(prediction["pred_detection_scores"][k]),
             "segmentation": encoded_masks[m],
             "mask_mean_score": mask_mean_scores[m],
@@ -279,6 +280,8 @@ def create_table(
                 SchemaField("counts", SqlTypeNames.STRING, mode="REQUIRED"),
             ],
         ),
+        SchemaField("bbox", SqlTypeNames.FLOAT, mode="REPEATED"),
+        SchemaField("mask_area_fraction", SqlTypeNames.FLOAT, mode="REQUIRED"),
         SchemaField("mask_mean_score", SqlTypeNames.FLOAT, mode="REQUIRED"),
     ]
 

--- a/cmd/segment/__main__.py
+++ b/cmd/segment/__main__.py
@@ -171,6 +171,7 @@ class COCOAnnotation(TypedDict):
     filename: str
     category_id: int
     bbox: list[float]
+    mask_area_fraction: float
     score: float
     segmentation: COCORLE
     mask_mean_score: float
@@ -235,6 +236,7 @@ def convert_predictions_to_coco_annotations(
             "bbox": (
                 prediction["pred_detection_boxes"][k].astype(np.float32) / eval_scale
             ).tolist(),
+            "mask_area_fraction": float(mask_areas[m]),
             "score": float(prediction["pred_detection_scores"][k]),
             "segmentation": encoded_masks[m],
             "mask_mean_score": mask_mean_scores[m],


### PR DESCRIPTION
# Change Summary
出力結果にbboxとmask_area_fractionを追加

# Why to Change

- 精度が悪いマスクを弾くためにmask_area_fractionが必要だったから
- bboxに関しては、今後マスク選択の改善をするにあたり必要になる可能性があるので

# How to Check and Result
コンフルのテストデータのリネージ通りに実行。
(miniデータで)ローカル、BQともに保存できていることを確認。

# Document Update
なし