### PR TITLE
Remove masks whose area is 0.

### DIFF
--- a/kaggle_imaterialist2020_model/transforms.py
+++ b/kaggle_imaterialist2020_model/transforms.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import numpy as np
 from evaluation.submission import get_new_image_size
 from pycocotools import mask as mask_api
@@ -78,20 +79,23 @@ def convert_predictions_to_coco_annotations(
 
     anns: list[COCOAnnotation] = []
     for m, k in enumerate(bbox_indices):
-        ann = COCOAnnotation(
-            image_id=image_id,
-            filename=filename,
-            category_id=int(prediction["pred_detection_classes"][k]),
-            # Avoid `astype(np.float32)` because
-            # it can't be serialized as JSON.
-            bbox=tuple(
-                float(x) for x in prediction["pred_detection_boxes"][k] / eval_scale
-            ),
-            mask_area_fraction=float(mask_area_fractions[m]),
-            score=float(prediction["pred_detection_scores"][k]),
-            segmentation=encoded_masks[m],
-            mask_mean_score=mask_mean_scores[m],
-        )
-        anns.append(ann)
+        mask_mean_score = mask_mean_scores[m]
+        # mask_mean_score is float("nan") when mask_area is 0.
+        if not math.isnan(mask_mean_score):
+            ann = COCOAnnotation(
+                image_id=image_id,
+                filename=filename,
+                category_id=int(prediction["pred_detection_classes"][k]),
+                # Avoid `astype(np.float32)` because
+                # it can't be serialized as JSON.
+                bbox=tuple(
+                    float(x) for x in prediction["pred_detection_boxes"][k] / eval_scale
+                ),
+                mask_area_fraction=float(mask_area_fractions[m]),
+                score=float(prediction["pred_detection_scores"][k]),
+                segmentation=encoded_masks[m],
+                mask_mean_score=mask_mean_score,
+            )
+            anns.append(ann)
 
     return anns


### PR DESCRIPTION
# Change Summary

予測から面積0のマスクの削除

# Why to Change

予測結果の、ほぼすべて利用先において不要なため。

# How to Check and Result

色抽出の実験パイプラインにおいて、 mask_mean_score が None になって dataclass に変換できなかった画像をリストアップ。

それらの画像に対する segment.py  の結果の json から `mask_mean_score: null` となるマスクが除かれたことを確認した。



# Document Update


不要